### PR TITLE
Fix package.json name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Ionic PouchDb Todo",
+    "name": "ionic-pouchdb-todo",
     "version": "1.1.0",
     "description": "An Example of the ng-pouchdb library in action",
     "repository" :


### PR DESCRIPTION
If you try to `npm install` with the current name, it will throw an error because the name has spaces in it.
