### PR TITLE
Update on 'Run App' section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ You can `cd` into the `www` directory and run
 ```bash
 python -m SimpleHTTPServer 8000
 ```
+If you're using Python 3.x or higher
+
+```bash
+python -m http.server 8000
+```
+
 
 You can then just open [http://localhost:8000/index.html](http://localhost:8000/index.html) in a browser.
 


### PR DESCRIPTION
This PR updates the instruction for start the app on python simple http server.

In version 3.x of Python, the module 'SimpleHTTPServer' has merged into 'http.server'

Reference: https://docs.python.org/2/library/simplehttpserver.html